### PR TITLE
Adds optional provisioning for Mail Hog and Elastic Search

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,4 +71,11 @@ Vagrant.configure("2") do |config|
 
     # php.ini files
     config.vm.provision "shell", path: "./provisioning/setup/php.sh"
+    
+    # Execute Mail Hog
+    #config.vm.provision "shell", path: "./provisioning/setup/mailhog.sh"
+
+    # Execute Elastic Search
+    #config.vm.provision "shell", path: "./provisioning/setup/elasticsearch.sh"
+     
 end

--- a/provisioning/setup/elasticsearch.sh
+++ b/provisioning/setup/elasticsearch.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" | sudo tee /etc/apt/sources.list.d/elastic-8.x.list
+
+sudo apt-get update && sudo apt-get install -y elasticsearch
+
+
+sudo systemctl enable elasticsearch
+sudo systemctl start elasticsearch
+
+sudo cp /etc/elasticsearch/certs/http_ca.crt /var/www/http_ca.crt
+                                                                                                              
+ echo "                                                                                                        
+================================================================================
+                                                                                
+Please read the security information above                                     
+                                                                              
+Save the super user password provided above                                  
+A copy of the generated http_ca.crt has been copied into /var/www                                                          
+                                                                              
+To test ElasticSearch is running:                                             
+                                                                               
+1) SSH into the vagrant box                                                  
+2) curl --cacert /var/www/http_ca.crt --user elastic 'https://localhost:9200' 
+                                                                                                                                                                                                         
+ ===============================================================================                                                                                                              
+"

--- a/provisioning/setup/mailhog.service
+++ b/provisioning/setup/mailhog.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=MailHog for local
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/root/go/bin/MailHog
+[Install]
+WantedBy=multi-user.target

--- a/provisioning/setup/mailhog.sh
+++ b/provisioning/setup/mailhog.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postfix
+wget  https://go.dev/dl/go1.20.2.linux-amd64.tar.gz
+tar -xvf go1.20.2.linux-amd64.tar.gz
+/home/vagrant/go/bin/go install github.com/mailhog/MailHog@latest
+sudo cp /var/www/provisioning/setup/mailhog.service /etc/systemd/system/mailhog.service
+sudo systemctl enable mailhog
+sudo sed -i 's/relayhost = $/relayhost = [localhost]:1025/g' /etc/postfix/main.cf
+
+echo "                                                                                                        
+================================================================================
+                                                                                
+You may need to reload vagrant before MailHog becomes available. 
+
+Web interface for Mail Hog in available on port 8025
+
+================================================================================
+"


### PR DESCRIPTION
Added scripts for installing Mail Hog and Elastic Search into Firefly. Neither are enabled by default. 